### PR TITLE
Feat - Kwaai AI Lab - Include dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+    apt-get install -y \
+        net-tools \
+        python3.10 \
+        python3-pip \
+        npm \
+        curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
+    update-alternatives --config python3
+
+WORKDIR /app/web
+COPY web/package*.json ./
+RUN npm install
+
+COPY web/ .
+
+WORKDIR /app/api
+COPY api/ .
+
+RUN pip install -r requirements.txt
+
+EXPOSE 4000
+EXPOSE 7860
+
+ENV OPENAI_API_KEY <SAMPLE_OPENAI_API_KEY>
+
+CMD ["sh", "-c", "python api.py & npm start"]


### PR DESCRIPTION
## Description
This pull request adds a Dockerfile to facilitate the deployment of PAIAssistant. The Dockerfile is designed to provide a containerized environment for running the PAIAssistant application, including both the Python API and the Node.js web application.

## Changes Made
- Added a Dockerfile to the project root.
- Configured the Dockerfile to install necessary dependencies for both Python and Node.js.
- Utilized a script to combine commands for starting the Python API and the Node.js application in a single CMD instruction.

## Usage
To build the Docker image:
```bash
docker build -t paiassistant:latest .
```

To run the Docker container:
```bash
docker run -p 4000:4000 -p 7860:7860 paiassistant:latest
```

Make sure to replace `<YOUR OPENAI API KEY>` with your actual OpenAI API key.

## Additional Notes
- The Dockerfile assumes the availability of an Ubuntu 20.04 LTS base image.
- Both Python 3.10 and npm are installed to support the Python API and the Node.js web application.
- The CMD instruction now uses a script to execute both Python API and Node.js application.